### PR TITLE
[feat] init connect DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ nosetests.xml
 .pytest_cache
 # Environments
 /local
-/.env
+*.env
 .venv
 ENV/
 env.bak/
@@ -56,6 +56,8 @@ env/
 venv
 venv.bak/
 venv/
+Pipfile
+Pipfile.lock
 # Misc
 .mypy_cache
 /staticfiles

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+django-environ==0.11.2
+psycopg2-binary==2.9.9

--- a/dopany/dopany/settings.py
+++ b/dopany/dopany/settings.py
@@ -11,9 +11,13 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
 from pathlib import Path
+import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+env = environ.Env()
+environ.Env.read_env(env.str('ENV_PATH', '.env'))
 
 
 # Quick-start development settings - unsuitable for production
@@ -37,6 +41,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "ETF"
 ]
 
 MIDDLEWARE = [
@@ -74,9 +79,17 @@ WSGI_APPLICATION = "dopany.wsgi.application"
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+    # "default": {
+    #     "ENGINE": "django.db.backends.sqlite3",
+    #     "NAME": BASE_DIR / "db.sqlite3",
+    # }
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': env('DB_NAME'),
+        'USER': env('DB_USER'),
+        'PASSWORD': env('DB_PASSWORD'),
+        'HOST': env('DB_HOST'),
+        'PORT': env('DB_PORT', default='5432'),
     }
 }
 


### PR DESCRIPTION
Django에 local PostgreSQL을 연결하는 설정을 추가했습니다.
To-Use의 절차에 따라 PostgreSQL을 로컬에서 사용할 수 있습니다.

Resolves:
- add dev-requirements 
    + django-environ : to use .env
    + psycopg2-binary : to use PostgreSQL
- add DATABASES params to connect PostgreSQL
- create .env to hide the params of 'settings.py > DATABASES'
- .gitignore : add venv(pipenv) ignore
 -----------------------------
**To-Use:**
1. pip install -r dev-requirements.txt
2. install PostgreSQL
3. create .env file under project root
4. python manage.py makemigrations
5. python manage.py migrate
 -----------------------------
**.env 작성 예시**
#Database configuration
DB_NAME=postgres # your_database_name
DB_USER=postgres # your_postgres_username
DB_PASSWORD= # your_postgres_password
DB_HOST=localhost
DB_PORT=5432